### PR TITLE
Indexer Fixes

### DIFF
--- a/flumeserver/flumehandler/handler.go
+++ b/flumeserver/flumehandler/handler.go
@@ -67,6 +67,9 @@ func bytesToAddress(data []byte) (common.Address) {
   return result
 }
 func bytesToAddressPtr(data []byte) (*common.Address) {
+  if len(data) == 0 {
+    return nil
+  }
   result := bytesToAddress(data)
   return &result
 }

--- a/flumeserver/flumehandler/handler.go
+++ b/flumeserver/flumehandler/handler.go
@@ -536,7 +536,7 @@ func getTransactions(ctx context.Context, db *sql.DB, offset, limit int, chainid
       rlp.DecodeBytes(accessListRLP, accessList)
       chainID = uintToHexBig(chainid)
     case types.LegacyTxType:
-      chainID = deriveChainID(v)
+      chainID = nil
     }
     results = append(results, &rpcTransaction{
       BlockHash: &blockHash,        //*common.Hash

--- a/flumeserver/flumehandler/handler.go
+++ b/flumeserver/flumehandler/handler.go
@@ -220,15 +220,15 @@ func getLogs(ctx context.Context, w http.ResponseWriter, call *rpcCall, db *sql.
   }
   whereClause = append(whereClause, "block <= ?")
   params = append(params, toBlock)
-  if crit.BlockHash == nil && toBlock - fromBlock < 2500 {
-    // If the block range is smaller than 2.5k, that's probably the best index
-    // otherwise we'll lean on the query planner. Note that even if the result
-    // set for filtering by blocks is bigger than the result set filtering by
-    // other fields, it can still end up being more efficient because logs
-    // sorted by blocks are sequential and can be read with fewer disk
-    // operations, so while it might be tempting to
-    indexClause = "INDEXED BY eventblock"
-  }
+  // if crit.BlockHash == nil && toBlock - fromBlock < 2500 {
+  //   // If the block range is smaller than 2.5k, that's probably the best index
+  //   // otherwise we'll lean on the query planner. Note that even if the result
+  //   // set for filtering by blocks is bigger than the result set filtering by
+  //   // other fields, it can still end up being more efficient because logs
+  //   // sorted by blocks are sequential and can be read with fewer disk
+  //   // operations, so while it might be tempting to
+  //   indexClause = "INDEXED BY eventblock"
+  // }
   addressClause := []string{}
   for _, address := range crit.Addresses {
     addressClause = append(addressClause, "address = ?")

--- a/flumeserver/indexer/indexer.go
+++ b/flumeserver/indexer/indexer.go
@@ -54,6 +54,12 @@ func compress(data []byte) []byte {
   return compressionBuffer.Bytes()
 }
 
+func getCopy(in []byte) []byte {
+  out := make([]byte, len(in))
+  copy(out, in)
+  return out
+}
+
 func getFuncSig(data []byte) ([]byte) {
   if len(data) >= 4 {
     return data[:4]
@@ -203,7 +209,7 @@ func ProcessDataFeed(feed datafeed.DataFeed, completionFeed event.Feed, db *sql.
             txwr.Transaction.Gas(),
             txwr.Transaction.GasPrice().Uint64(),
             txHash,
-            compress(txwr.Transaction.Data()),
+            getCopy(compress(txwr.Transaction.Data())),
             txwr.Transaction.Nonce(),
             to,
             txwr.Receipt.TransactionIndex,
@@ -216,7 +222,7 @@ func ProcessDataFeed(feed datafeed.DataFeed, completionFeed event.Feed, db *sql.
             txwr.Receipt.ContractAddress,
             txwr.Receipt.CumulativeGasUsed,
             txwr.Receipt.GasUsed,
-            compress(txwr.Receipt.Bloom.Bytes()),
+            getCopy(compress(txwr.Receipt.Bloom.Bytes())),
             txwr.Receipt.Status,
             txwr.Transaction.Type(),
             compress(accessListRLP),

--- a/flumeserver/indexer/indexer.go
+++ b/flumeserver/indexer/indexer.go
@@ -94,10 +94,14 @@ func ProcessDataFeed(feed datafeed.DataFeed, completionFeed event.Feed, db *sql.
   log.Printf("Processing data feed")
   ch := make(chan *datafeed.ChainEvent, 10)
   sub := feed.Subscribe(ch)
+  processed := false
   defer sub.Unsubscribe()
   for {
     select {
     case <-quit:
+      if !processed {
+        panic("Shutting down without processing any blocks")
+      }
       log.Printf("Shutting down index process")
       return
     case chainEvent := <- ch:
@@ -254,6 +258,7 @@ func ProcessDataFeed(feed datafeed.DataFeed, completionFeed event.Feed, db *sql.
           continue BLOCKLOOP
         }
         wg.Done()
+        processed = true
         completionFeed.Send(chainEvent.Block.Hash)
         // log.Printf("Spent %v on commit", time.Since(cstart))
         log.Printf("Committed Block %v (%#x) in %v (age %v)", uint64(chainEvent.Block.Number.ToInt().Int64()), chainEvent.Block.Hash.Bytes(), time.Since(start), time.Since(time.Unix(int64(chainEvent.Block.Timestamp), 0)))

--- a/flumeserver/indexer/indexer.go
+++ b/flumeserver/indexer/indexer.go
@@ -78,7 +78,7 @@ func applyParameters(query string, params ...interface{}) string {
     case bytesable:
       preparedParams[i] = fmt.Sprintf("X'%x'", trimPrefix(value.Bytes()))
     case hexutil.Bytes:
-      preparedParams[i] = fmt.Sprintf("X'%x'", value[:])
+      preparedParams[i] = fmt.Sprintf("X'%x'", []byte(value[:]))
     case hexutil.Uint64:
       preparedParams[i] = fmt.Sprintf("%v", uint64(value))
     case types.BlockNonce:

--- a/flumeserver/main.go
+++ b/flumeserver/main.go
@@ -107,6 +107,13 @@ func main() {
       log.Printf("SQLite Pool - Open: %v InUse: %v Idle: %v", stats.OpenConnections, stats.InUse, stats.Idle)
     }
   }()
+  p := &http.Server{
+    Addr: ":6969",
+    Handler: http.DefaultServeMux,
+    ReadHeaderTimeout: 5 * time.Second,
+    MaxHeaderBytes: 1 << 20,
+  }
+  go p.ListenAndServe()
   if err := migrations.Migrate(logsdb, chainid); err != nil {
     log.Fatalf(err.Error())
   }
@@ -129,13 +136,6 @@ func main() {
     ReadHeaderTimeout: 5 * time.Second,
     MaxHeaderBytes: 1 << 20,
   }
-  p := &http.Server{
-    Addr: ":6969",
-    Handler: http.DefaultServeMux,
-    ReadHeaderTimeout: 5 * time.Second,
-    MaxHeaderBytes: 1 << 20,
-  }
-  go p.ListenAndServe()
   <-feed.Ready()
   if *completionTopic != "" {
     notify.SendKafkaNotifications(completionFeed, *completionTopic)


### PR DESCRIPTION
We had some values that weren't being loaded into the database correctly.

The compress() function was returning slices of the same array each time, meaning subsequent calls were changing the underlying data. This changes to make a copy, where appropriate, to avoid having all the compressed values in a transaction entry reflect the last call to compress().

Additionally, we had some values that were being hex encoded before writing to the database, which was not our intent.

These issues were fixed in our databases out-of-band. If anyone is currently running an impacted version of flume, contact us for help with corrections.